### PR TITLE
Handle missing config fallback and add new recipes

### DIFF
--- a/asset/recipes/cjson.lua
+++ b/asset/recipes/cjson.lua
@@ -1,0 +1,31 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'DaveGamble/cJSON',
+  lib = 'cjson',
+  kinds = { 'shared', 'source' },
+  build = function(builder)
+    builder:copy({
+      { builder:source('cJSON.h'), builder:include() },
+    })
+
+    if builder.kind == 'source' then
+      builder:copy({
+        { builder:source('cJSON.c'), builder:vendor() },
+      })
+    else
+      builder:cc({
+        compiler = 'cc',
+        shared = true,
+        source = { 'cJSON.c' },
+        output = 'libcjson.so',
+      })
+
+      builder:copy({
+        { builder:work('libcjson.so'), builder:lib() },
+      })
+    end
+  end,
+})
+
+return recipe

--- a/asset/recipes/curl.lua
+++ b/asset/recipes/curl.lua
@@ -1,0 +1,22 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'curl/curl',
+  lib = 'curl',
+  kinds = { 'shared', 'static' },
+  build = function(builder)
+    local shared = builder.kind == 'shared'
+    builder:cmake({
+      defines = {
+        { 'BUILD_SHARED_LIBS', shared },
+        { 'BUILD_TESTING', false },
+        { 'CURL_DISABLE_TESTS', true },
+        { 'CURL_DISABLE_EXAMPLES', true },
+      },
+      install = true,
+    })
+
+  end,
+})
+
+return recipe

--- a/asset/recipes/freetype.lua
+++ b/asset/recipes/freetype.lua
@@ -1,0 +1,23 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'freetype/freetype',
+  lib = 'freetype',
+  kinds = { 'shared', 'static' },
+  build = function(builder)
+    local shared = builder.kind == 'shared'
+    builder:cmake({
+      defines = {
+        { 'BUILD_SHARED_LIBS', shared },
+      },
+      install = true,
+    })
+
+    builder:copy({
+      { builder:store('include/freetype2/ft2build.h'), builder:include() },
+      { builder:store('include/freetype2/freetype'), builder:include() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/glfw.lua
+++ b/asset/recipes/glfw.lua
@@ -1,0 +1,22 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'glfw/glfw',
+  lib = 'glfw',
+  kinds = { 'shared', 'static' },
+  build = function(builder)
+    local shared = builder.kind == 'shared'
+    builder:cmake({
+      defines = {
+        { 'BUILD_SHARED_LIBS', shared },
+        { 'GLFW_BUILD_EXAMPLES', false },
+        { 'GLFW_BUILD_TESTS', false },
+        { 'GLFW_BUILD_DOCS', false },
+      },
+      install = true,
+    })
+
+  end,
+})
+
+return recipe

--- a/asset/recipes/hmm.lua
+++ b/asset/recipes/hmm.lua
@@ -1,0 +1,13 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'HandmadeMath/Handmade-Math',
+  kinds = { 'source' },
+  build = function(builder)
+    builder:copy({
+      { builder:source('HandmadeMath.h'), builder:include() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/linenoise.lua
+++ b/asset/recipes/linenoise.lua
@@ -1,0 +1,31 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'antirez/linenoise',
+  lib = 'linenoise',
+  kinds = { 'shared', 'source' },
+  build = function(builder)
+    builder:copy({
+      { builder:source('linenoise.h'), builder:include() },
+    })
+
+    if builder.kind == 'source' then
+      builder:copy({
+        { builder:source('linenoise.c'), builder:vendor() },
+      })
+    else
+      builder:cc({
+        compiler = 'cc',
+        shared = true,
+        source = { 'linenoise.c' },
+        output = 'liblinenoise.so',
+      })
+
+      builder:copy({
+        { builder:work('liblinenoise.so'), builder:lib() },
+      })
+    end
+  end,
+})
+
+return recipe

--- a/asset/recipes/microui.lua
+++ b/asset/recipes/microui.lua
@@ -1,0 +1,18 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'rxi/microui',
+  lib = 'microui',
+  kinds = { 'source' },
+  include = {
+    vendor = true,
+  },
+  build = function(builder)
+    builder:copy({
+      { builder:source('src/microui.h'), builder:include() },
+      { builder:source('src/microui.c'), builder:vendor() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/miniz.lua
+++ b/asset/recipes/miniz.lua
@@ -1,0 +1,40 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'richgel999/miniz',
+  lib = 'miniz',
+  kinds = { 'source' },
+  include = {
+    vendor = true,
+  },
+  build = function(builder)
+    builder:copy({
+      { builder:source('miniz.h'), builder:include() },
+      { builder:source('miniz_common.h'), builder:include() },
+      { builder:source('miniz_tdef.h'), builder:include() },
+      { builder:source('miniz_tinfl.h'), builder:include() },
+      { builder:source('miniz_zip.h'), builder:include() },
+      { builder:source('miniz.c'), builder:vendor() },
+      { builder:source('miniz_tdef.c'), builder:vendor() },
+      { builder:source('miniz_tinfl.c'), builder:vendor() },
+    })
+
+    local export_header = builder:include('miniz_export.h')
+    builder:sh({
+      command = 'sh',
+      args = {
+        '-c',
+        string.format([[cat <<'EOF' > %s
+#ifndef MINIZ_EXPORT_H
+#define MINIZ_EXPORT_H
+#define MINIZ_EXPORT
+#define MINIZ_NO_EXPORT
+#endif
+EOF
+]], export_header.absolute)
+      }
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/nuklear.lua
+++ b/asset/recipes/nuklear.lua
@@ -1,0 +1,14 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'Immediate-Mode-UI/Nuklear',
+  kinds = { 'source' },
+  build = function(builder)
+    builder:copy({
+      { builder:source('nuklear.h'), builder:include() },
+      { builder:source('demo'), builder:include() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/quickjs.lua
+++ b/asset/recipes/quickjs.lua
@@ -1,0 +1,24 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'bellard/quickjs',
+  lib = 'quickjs',
+  kinds = { 'static' },
+  build = function(builder)
+    builder:sh({
+      command = 'make',
+      args = {
+        '-C', builder.paths.source,
+        'libquickjs.a',
+      },
+    })
+
+    builder:copy({
+      { builder:source('quickjs.h'), builder:include() },
+      { builder:source('quickjs-libc.h'), builder:include() },
+      { builder:source('libquickjs.a'), builder:lib() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/raylib.lua
+++ b/asset/recipes/raylib.lua
@@ -1,0 +1,28 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'raysan5/raylib',
+  lib = 'raylib',
+  kinds = { 'shared', 'static' },
+  build = function(builder)
+    local shared = builder.kind == 'shared'
+    builder:cmake({
+      defines = {
+        { 'BUILD_SHARED_LIBS', shared },
+        { 'BUILD_EXAMPLES', false },
+        { 'BUILD_GAMES', false },
+      },
+      install = true,
+    })
+
+    builder:copy({
+      { builder:source('src/raylib.h'), builder:include() },
+      { builder:source('src/rlgl.h'), builder:include() },
+      { builder:source('src/raymath.h'), builder:include() },
+      { builder:source('src/extras'), builder:include('extras') },
+      { builder:store(shared and 'lib/libraylib.so' or 'lib/libraylib.a'), builder:lib() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/sds.lua
+++ b/asset/recipes/sds.lua
@@ -1,0 +1,31 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'antirez/sds',
+  lib = 'sds',
+  kinds = { 'shared', 'source' },
+  build = function(builder)
+    builder:copy({
+      { builder:source('sds.h'), builder:include() },
+    })
+
+    if builder.kind == 'source' then
+      builder:copy({
+        { builder:source('sds.c'), builder:vendor() },
+      })
+    else
+      builder:cc({
+        compiler = 'cc',
+        shared = true,
+        source = { 'sds.c' },
+        output = 'libsds.so',
+      })
+
+      builder:copy({
+        { builder:work('libsds.so'), builder:lib() },
+      })
+    end
+  end,
+})
+
+return recipe

--- a/asset/recipes/sodium.lua
+++ b/asset/recipes/sodium.lua
@@ -1,0 +1,47 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'jedisct1/libsodium',
+  lib = 'sodium',
+  kinds = { 'shared', 'static' },
+  build = function(builder)
+    local shared = builder.kind == 'shared'
+    local source = builder.paths.source
+    local prefix = builder.paths.store
+    local shared_flag = shared and '--enable-shared --disable-static' or '--disable-shared --enable-static'
+
+    builder:sh({
+      command = 'sh',
+      args = {
+        '-c',
+        string.format('cd %s && ./autogen.sh -s', source),
+      },
+    })
+
+    builder:sh({
+      command = 'sh',
+      args = {
+        '-c',
+        string.format('cd %s && ./configure --prefix=%s %s', source, prefix, shared_flag),
+      },
+    })
+
+    builder:sh({
+      command = 'sh',
+      args = {
+        '-c',
+        string.format('cd %s && make -j8', source),
+      },
+    })
+
+    builder:sh({
+      command = 'sh',
+      args = {
+        '-c',
+        string.format('cd %s && make install', source),
+      },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/sokol.lua
+++ b/asset/recipes/sokol.lua
@@ -1,0 +1,14 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'floooh/sokol',
+  kinds = { 'source' },
+  build = function(builder)
+    builder:copy({
+      { builder:source('*.h'), builder:include() },
+      { builder:source('util'), builder:include() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/stb.lua
+++ b/asset/recipes/stb.lua
@@ -1,0 +1,13 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'nothings/stb',
+  kinds = { 'source' },
+  build = function(builder)
+    builder:copy({
+      { builder:source('*.h'), builder:include() },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/tree-sitter.lua
+++ b/asset/recipes/tree-sitter.lua
@@ -1,0 +1,28 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'tree-sitter/tree-sitter',
+  lib = 'tree-sitter',
+  kinds = { 'static' },
+  build = function(builder)
+    builder:sh({
+      command = 'make',
+      args = {
+        '-C', builder.paths.source,
+        '-j8',
+        string.format('PREFIX=%s', builder.paths.store),
+      },
+    })
+
+    builder:sh({
+      command = 'make',
+      args = {
+        '-C', builder.paths.source,
+        string.format('PREFIX=%s', builder.paths.store),
+        'install',
+      },
+    })
+  end,
+})
+
+return recipe

--- a/asset/recipes/uv.lua
+++ b/asset/recipes/uv.lua
@@ -1,0 +1,22 @@
+local spn = require('spn')
+
+local recipe = spn.recipes.basic({
+  git = 'libuv/libuv',
+  lib = 'uv',
+  kinds = { 'shared', 'static' },
+  build = function(builder)
+    local shared = builder.kind == 'shared'
+    builder:cmake({
+      defines = {
+        { 'LIBUV_BUILD_TESTS', false },
+        { 'LIBUV_BUILD_BENCHMARKS', false },
+        { 'LIBUV_BUILD_SHARED', shared },
+        { 'LIBUV_BUILD_STATIC', not shared },
+      },
+      install = true,
+    })
+
+  end,
+})
+
+return recipe

--- a/examples/cjson/main.c
+++ b/examples/cjson/main.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <cJSON.h>
+
+int main(void) {
+  cJSON *root = cJSON_CreateObject();
+  cJSON_AddNumberToObject(root, "value", 42);
+  char *text = cJSON_PrintUnformatted(root);
+  printf("%s\n", text);
+  cJSON_free(text);
+  cJSON_Delete(root);
+  return 0;
+}

--- a/examples/cjson/spn.lua
+++ b/examples/cjson/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'cjson',
+  deps = {
+    cjson = {},
+  },
+}
+
+return project

--- a/examples/curl/main.c
+++ b/examples/curl/main.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main(void) {
+  if (curl_global_init(CURL_GLOBAL_DEFAULT) != 0) {
+    fprintf(stderr, "curl init failed\n");
+    return 1;
+  }
+  CURL *handle = curl_easy_init();
+  if (handle) {
+    curl_easy_cleanup(handle);
+  }
+  curl_global_cleanup();
+  puts("curl ready");
+  return 0;
+}

--- a/examples/curl/spn.lua
+++ b/examples/curl/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'curl',
+  deps = {
+    curl = {},
+  },
+}
+
+return project

--- a/examples/freetype/main.c
+++ b/examples/freetype/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+int main(void) {
+  FT_Library library;
+  if (FT_Init_FreeType(&library) != 0) {
+    fprintf(stderr, "failed to initialize freetype\n");
+    return 1;
+  }
+  int major = 0;
+  int minor = 0;
+  int patch = 0;
+  FT_Library_Version(library, &major, &minor, &patch);
+  printf("freetype version: %d.%d.%d\n", major, minor, patch);
+  FT_Done_FreeType(library);
+  return 0;
+}

--- a/examples/freetype/spn.lua
+++ b/examples/freetype/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'freetype',
+  deps = {
+    freetype = {},
+  },
+}
+
+return project

--- a/examples/glfw/main.c
+++ b/examples/glfw/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <GLFW/glfw3.h>
+
+int main(void) {
+  printf("glfw version: %s\n", glfwGetVersionString());
+  return 0;
+}

--- a/examples/glfw/spn.lua
+++ b/examples/glfw/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'glfw',
+  deps = {
+    glfw = {},
+  },
+}
+
+return project

--- a/examples/hmm/main.c
+++ b/examples/hmm/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <HandmadeMath.h>
+
+int main(void) {
+  HMM_Vec3 a = HMM_V3(1.0f, 2.0f, 3.0f);
+  HMM_Vec3 b = HMM_V3(4.0f, 5.0f, 6.0f);
+  HMM_Vec3 sum = HMM_AddV3(a, b);
+  printf("sum: %.1f %.1f %.1f\n", sum.X, sum.Y, sum.Z);
+  return 0;
+}

--- a/examples/hmm/spn.lua
+++ b/examples/hmm/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'hmm',
+  deps = {
+    hmm = {},
+  },
+}
+
+return project

--- a/examples/linenoise/main.c
+++ b/examples/linenoise/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <linenoise.h>
+
+int main(void) {
+  linenoiseSetMultiLine(1);
+  linenoiseHistoryAdd("hello");
+  linenoiseHistoryAdd("world");
+  printf("linenoise ready\n");
+  return 0;
+}

--- a/examples/linenoise/spn.lua
+++ b/examples/linenoise/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'linenoise',
+  deps = {
+    linenoise = {},
+  },
+}
+
+return project

--- a/examples/microui/main.c
+++ b/examples/microui/main.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <string.h>
+#include <microui.h>
+#include <microui.c>
+
+static int text_width(mu_Font font, const char *text, int len) {
+  (void) font;
+  if (len < 0) {
+    len = (int) strlen(text);
+  }
+  return len * 8;
+}
+
+static int text_height(mu_Font font) {
+  (void) font;
+  return 16;
+}
+
+int main(void) {
+  mu_Context ctx;
+  mu_init(&ctx);
+  ctx.text_width = text_width;
+  ctx.text_height = text_height;
+  mu_begin(&ctx);
+  mu_end(&ctx);
+  printf("frame: %d\n", ctx.frame);
+  return 0;
+}

--- a/examples/microui/spn.lua
+++ b/examples/microui/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'microui',
+  deps = {
+    microui = {},
+  },
+}
+
+return project

--- a/examples/miniz/main.c
+++ b/examples/miniz/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <miniz.h>
+#include <miniz.c>
+#include <miniz_tdef.c>
+#include <miniz_tinfl.c>
+
+int main(void) {
+  mz_ulong crc = mz_crc32(MZ_CRC32_INIT, (const unsigned char*)"spn", 3);
+  printf("crc32: %u\n", (unsigned) crc);
+  return 0;
+}

--- a/examples/miniz/spn.lua
+++ b/examples/miniz/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'miniz',
+  deps = {
+    miniz = {},
+  },
+}
+
+return project

--- a/examples/nuklear/main.c
+++ b/examples/nuklear/main.c
@@ -1,0 +1,7 @@
+#define NK_IMPLEMENTATION
+#include <nuklear.h>
+
+int main(void) {
+  struct nk_color color = nk_rgb(255, 0, 0);
+  return color.r == 255 ? 0 : 1;
+}

--- a/examples/nuklear/spn.lua
+++ b/examples/nuklear/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'nuklear',
+  deps = {
+    nuklear = {},
+  },
+}
+
+return project

--- a/examples/quickjs/main.c
+++ b/examples/quickjs/main.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <quickjs.h>
+
+int main(void) {
+  JSRuntime *rt = JS_NewRuntime();
+  JSContext *ctx = JS_NewContext(rt);
+  JSValue value = JS_NewInt32(ctx, 42);
+  int32_t out = 0;
+  JS_ToInt32(ctx, &out, value);
+  printf("quickjs value: %d\n", out);
+  JS_FreeValue(ctx, value);
+  JS_FreeContext(ctx);
+  JS_FreeRuntime(rt);
+  return 0;
+}

--- a/examples/quickjs/spn.lua
+++ b/examples/quickjs/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'quickjs',
+  deps = {
+    quickjs = {},
+  },
+}
+
+return project

--- a/examples/raylib/main.c
+++ b/examples/raylib/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <raylib.h>
+
+int main(void) {
+  printf("raylib version: %s\n", RAYLIB_VERSION);
+  return 0;
+}

--- a/examples/raylib/spn.lua
+++ b/examples/raylib/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'raylib',
+  deps = {
+    raylib = {},
+  },
+}
+
+return project

--- a/examples/sds/main.c
+++ b/examples/sds/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <sds.h>
+
+int main(void) {
+  sds value = sdsnew("hello");
+  value = sdscat(value, " world");
+  printf("%s\n", value);
+  sdsfree(value);
+  return 0;
+}

--- a/examples/sds/spn.lua
+++ b/examples/sds/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'sds',
+  deps = {
+    sds = {},
+  },
+}
+
+return project

--- a/examples/sodium/main.c
+++ b/examples/sodium/main.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <sodium.h>
+
+int main(void) {
+  if (sodium_init() < 0) {
+    fprintf(stderr, "failed to initialize libsodium\n");
+    return 1;
+  }
+  unsigned char hash[crypto_hash_sha256_BYTES];
+  crypto_hash_sha256(hash, (const unsigned char*)"spn", 3);
+  printf("hash length: %zu\n", sizeof hash);
+  return 0;
+}

--- a/examples/sodium/spn.lua
+++ b/examples/sodium/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'sodium',
+  deps = {
+    sodium = {},
+  },
+}
+
+return project

--- a/examples/sokol/main.c
+++ b/examples/sokol/main.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdint.h>
+
+#define SOKOL_IMPL
+#define SOKOL_TIME_IMPL
+#include <sokol_time.h>
+
+int main(void) {
+  stm_setup();
+  uint64_t start = stm_now();
+  uint64_t end = stm_now();
+  printf("elapsed: %.6f seconds\n", stm_sec(end - start));
+  return 0;
+}

--- a/examples/sokol/spn.lua
+++ b/examples/sokol/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'sokol',
+  deps = {
+    sokol = {},
+  },
+}
+
+return project

--- a/examples/stb/main.c
+++ b/examples/stb/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+
+int main(void) {
+  stbi_set_flip_vertically_on_load(1);
+  printf("stb image version: %d\n", STBI_VERSION);
+  return 0;
+}

--- a/examples/stb/spn.lua
+++ b/examples/stb/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'stb',
+  deps = {
+    stb = {},
+  },
+}
+
+return project

--- a/examples/treesitter/main.c
+++ b/examples/treesitter/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <tree_sitter/api.h>
+
+int main(void) {
+  TSParser *parser = ts_parser_new();
+  printf("parser: %p\n", (void *) parser);
+  ts_parser_delete(parser);
+  return 0;
+}

--- a/examples/treesitter/spn.lua
+++ b/examples/treesitter/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'treesitter',
+  deps = {
+    ['tree-sitter'] = {},
+  },
+}
+
+return project

--- a/examples/uv/main.c
+++ b/examples/uv/main.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <uv.h>
+
+int main(void) {
+  uv_loop_t loop;
+  if (uv_loop_init(&loop) != 0) {
+    fprintf(stderr, "failed to initialize loop\n");
+    return 1;
+  }
+  printf("libuv loop alive: %d\n", uv_loop_alive(&loop));
+  uv_loop_close(&loop);
+  return 0;
+}

--- a/examples/uv/spn.lua
+++ b/examples/uv/spn.lua
@@ -1,0 +1,8 @@
+local project = {
+  name = 'uv',
+  deps = {
+    uv = {},
+  },
+}
+
+return project

--- a/source/spn.lua
+++ b/source/spn.lua
@@ -114,9 +114,16 @@ function spn.init(app)
   -- Load the project agnostic user config
   app = ffi.cast('spn_lua_context_t*', app)
   spn.app = app
-  local config = dofile(app.paths.user_config:cstr())
-  if not config then
-    return
+  local config = {}
+  local loader = loadfile(app.paths.user_config:cstr())
+  if loader then
+    local ok, result = pcall(loader)
+    if not ok then
+      error(string.format('failed to evaluate user config %s: %s', app.paths.user_config:cstr(), result))
+    end
+    if type(result) == 'table' then
+      config = result
+    end
   end
 
   if config.spn then


### PR DESCRIPTION
## Summary
- fall back to cloning the spn repository when no user config is present and prefer local sources when available
- add build recipes and minimal examples for stb, freetype, cjson, raylib, hmm, microui, uv, sodium, tree-sitter, curl, sokol, sds, glfw, nuklear, quickjs, miniz, and linenoise

## Testing
- make bootstrap
- make clay
- make sqlite
- make imgui
- make luajit
- for target in stb hmm sokol nuklear miniz sds linenoise microui cjson freetype raylib uv sodium treesitter curl glfw quickjs; do make $target; done
- for target in stb hmm sokol nuklear miniz sds linenoise microui cjson freetype raylib uv sodium treesitter curl glfw quickjs; do build/examples/$target/main; done

------
https://chatgpt.com/codex/tasks/task_e_68d231751a10832da27c603eb6eb88e7